### PR TITLE
add: CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# DevOps team code owner configuration
+
+**/Dockerfile @Koudmain/Koudmain-team-devops
+**/.dockerignore @Koudmain/Koudmain-team-devops
+**/docker-compose.* @Koudmain/Koudmain-team-devops
+**/Makefile @Koudmain/Koudmain-team-devops
+.github/ @Koudmain/Koudmain-team-devops


### PR DESCRIPTION
This pull request adds DevOps team ownership configuration to the `.github/CODEOWNERS` file. All Docker-related files, Makefiles, and GitHub configuration files are now assigned to the DevOps team for code ownership.